### PR TITLE
Add Terraform configuration for EKS and Kubernetes deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ cmd/workload/workload
 /hardhat/package-lock.json
 /hardhat/cache
 /hardhat/artifacts
+
+/aws
+.terraform
+.terraform.lock.hcl
+terraform.tfstate
+.terraform.tfstate.lock.info

--- a/terraform/k8s/main.tf
+++ b/terraform/k8s/main.tf
@@ -1,0 +1,186 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# VPC and Network Configuration
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "eks-vpc"
+  }
+}
+
+# Subnets
+resource "aws_subnet" "main" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "eks-subnet-${count.index + 1}"
+  }
+}
+
+# IAM Roles and Policies
+resource "aws_iam_role" "eks_cluster" {
+  name = "eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "eks_nodes" {
+  name = "eks-node-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks_cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_node_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks_nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks_nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read_only" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks_nodes.name
+}
+
+# EKS Cluster
+resource "aws_eks_cluster" "main" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = "1.28"
+
+  vpc_config {
+    subnet_ids = aws_subnet.main[*].id
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_cluster_policy
+  ]
+}
+
+# Node Group
+resource "aws_eks_node_group" "main" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = var.node_group_name
+  node_role_arn   = aws_iam_role.eks_nodes.arn
+  subnet_ids      = aws_subnet.main[*].id
+
+  scaling_config {
+    desired_size = var.node_desired_size
+    max_size     = var.node_max_size
+    min_size     = var.node_min_size
+  }
+
+  instance_types = var.instance_types
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_worker_node_policy,
+    aws_iam_role_policy_attachment.eks_cni_policy,
+    aws_iam_role_policy_attachment.ecr_read_only
+  ]
+}
+
+# Data sources
+data "aws_availability_zones" "available" {}
+
+# Kubernetes Deployment
+resource "kubernetes_deployment" "go_ethereum" {
+  metadata {
+    name = "go-ethereum"
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "go-ethereum"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "go-ethereum"
+        }
+      }
+
+      spec {
+        container {
+          image = "ethereum/client-go:stable"
+          name  = "go-ethereum"
+
+          port {
+            container_port = 8545
+          }
+        }
+      }
+    }
+  }
+}
+
+# Kubernetes Service
+resource "kubernetes_service" "go_ethereum" {
+  metadata {
+    name = "go-ethereum"
+  }
+
+  spec {
+    selector = {
+      app = "go-ethereum"
+    }
+
+    port {
+      port        = 8545
+      target_port = 8545
+    }
+
+    type = "LoadBalancer"
+  }
+} 

--- a/terraform/k8s/outputs.tf
+++ b/terraform/k8s/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = aws_eks_cluster.main.endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster"
+  value       = aws_eks_cluster.main.vpc_config[0].cluster_security_group_id
+}
+
+output "cluster_name" {
+  description = "Name of the Kubernetes cluster"
+  value       = aws_eks_cluster.main.name
+}
+
+output "load_balancer_hostname" {
+  description = "Hostname of the LoadBalancer service"
+  value       = kubernetes_service.go_ethereum.status.0.load_balancer.0.ingress.0.hostname
+} 

--- a/terraform/k8s/provider.tf
+++ b/terraform/k8s/provider.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.main.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--cluster-name",
+      aws_eks_cluster.main.name
+    ]
+  }
+} 

--- a/terraform/k8s/variables.tf
+++ b/terraform/k8s/variables.tf
@@ -1,0 +1,41 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+  default     = "go-ethereum-cluster"
+}
+
+variable "node_group_name" {
+  description = "Name of the node group"
+  type        = string
+  default     = "main"
+}
+
+variable "node_desired_size" {
+  description = "Desired number of nodes"
+  type        = number
+  default     = 2
+}
+
+variable "node_max_size" {
+  description = "Maximum number of nodes"
+  type        = number
+  default     = 3
+}
+
+variable "node_min_size" {
+  description = "Minimum number of nodes"
+  type        = number
+  default     = 1
+}
+
+variable "instance_types" {
+  description = "Type of EC2 instances"
+  type        = list(string)
+  default     = ["t3.micro"]
+} 


### PR DESCRIPTION
- Introduced new Terraform files for setting up an EKS cluster and Kubernetes resources, including VPC, subnets, IAM roles, and policies.
- Added outputs for cluster details and a Kubernetes deployment for the Go Ethereum client.
- Updated .gitignore to include Terraform state files and directories for better project management.